### PR TITLE
docs: agrega documentación de CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,45 +203,21 @@ Estado del Proyecto
 
 
 
+## CI/CD – Validación del Frontend
 
+El repositorio cuenta con un pipeline de Integración Continua configurado en:
 
+.github/workflows/ci.yml
 
+Este pipeline ejecuta:
 
+- pnpm install
+- pnpm build
 
+El comando `pnpm build` construye todas las aplicaciones del monorepo, incluyendo el frontend desarrollado con Next.js.  
+Si el frontend presenta errores de compilación, el build falla automáticamente y el Pull Request no puede integrarse.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+La configuración de protección de ramas requiere permisos de administrador del repositorio, por lo que debe ser activada por el propietario del proyecto.
 
 
 


### PR DESCRIPTION
El repositorio ya cuenta con un pipeline de Integración Continua que valida automáticamente el frontend. En el proceso de CI se construyen todas las aplicaciones del monorepo, lo que garantiza que cualquier error en el frontend impida la integración de cambios.
- Se configuró GitHub Actions en .github/workflows/ci.yml.

El pipeline ejecuta los comandos:
* pnpm install
* pnpm build
El comando pnpm build incluye la construcción del frontend desarrollado con Next.js.

Si el proceso de CI falla, el merge del PR queda bloqueado.